### PR TITLE
docs updated for client localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ API_URL=http://localhost:5000
 cd server && npm run dev
 
 # Terminal 2
-cd client && npm run dev
+cd client && npm start
 
 # Terminal 3
 cd bot && node index.js

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16339,20 +16339,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",


### PR DESCRIPTION
<img width="645" height="155" alt="Screenshot 2025-08-12 172436" src="https://github.com/user-attachments/assets/8ed1af4b-6664-4e8c-9bd1-53a82e11c176" />

Showing **ERROR** for client localhost due to "**npm run dev**" command.
I have update the documentation for client localhost, that is "**npm start**" now working good.

You can watch below 

<img width="1109" height="599" alt="Screenshot 2025-08-12 172826" src="https://github.com/user-attachments/assets/89cc24ce-150c-4569-9281-b6d93d548822" />
 
