### PR TITLE
Feat/discord commands setup

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,0 +1,5 @@
+# Copy to .env and fill your values
+DISCORD_TOKEN=
+CLIENT_ID=
+# Optional for faster per-guild command registration during development
+GUILD_ID=

--- a/bot/README.md
+++ b/bot/README.md
@@ -4,6 +4,15 @@
 - Create a Discord application and bot, invite it with scopes: `bot applications.commands`.
 - In the Dev Portal, enable the intents you use. This project uses `Guilds`, `GuildMessages`, and `MessageContent`.
 
+### Quick start
+
+```
+npm install
+# set env in bot/.env (see below)
+npm run deploy:commands
+npm run start
+```
+
 ### Environment
 Create a `.env` file in `bot/` with:
 
@@ -14,13 +23,10 @@ CLIENT_ID=your-application-id
 GUILD_ID=your-guild-id
 ```
 
-### Install and run
-
-```
-npm install
-npm run deploy:commands
-npm run start
-```
+### Scripts
+- `npm run start`: start the bot
+- `npm run dev`: start with auto-reload (nodemon)
+- `npm run deploy:commands`: register slash commands (run this after adding/editing commands)
 
 ### Folder structure
 - `commands/`: One file per slash command exporting `{ data, execute }`.

--- a/bot/README.md
+++ b/bot/README.md
@@ -1,0 +1,56 @@
+## Discord bot commands setup
+
+### Prerequisites
+- Create a Discord application and bot, invite it with scopes: `bot applications.commands`.
+- In the Dev Portal, enable the intents you use. This project uses `Guilds`, `GuildMessages`, and `MessageContent`.
+
+### Environment
+Create a `.env` file in `bot/` with:
+
+```
+DISCORD_TOKEN=your-bot-token
+CLIENT_ID=your-application-id
+# Optional for faster iteration (guild-scoped registration)
+GUILD_ID=your-guild-id
+```
+
+### Install and run
+
+```
+npm install
+npm run deploy:commands
+npm run start
+```
+
+### Folder structure
+- `commands/`: One file per slash command exporting `{ data, execute }`.
+- `events/`: Discord event handlers exporting `{ name, once?, execute }`.
+- `index.js`: Bootstraps the client, loads commands and events.
+- `deploy-commands.js`: Registers slash commands from `commands/`.
+
+### Create a new command
+Add a file under `commands/`, for example `hello.js`:
+
+```js
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('hello')
+    .setDescription('Say hello'),
+  async execute(interaction) {
+    await interaction.reply('Hello!');
+  },
+};
+```
+
+Then register it and start the bot:
+
+```
+npm run deploy:commands
+npm run start
+```
+
+
+
+

--- a/bot/commands/ping.js
+++ b/bot/commands/ping.js
@@ -1,0 +1,17 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('ping')
+    .setDescription('Replies with Pong!'),
+  async execute(interaction) {
+    const reply = await interaction.reply({ content: 'Pong!', fetchReply: true });
+    const latencyMs = reply.createdTimestamp - interaction.createdTimestamp;
+    const websocketMs = Math.round(interaction.client.ws.ping);
+    await interaction.followUp(`Latency: ${latencyMs}ms | WebSocket: ${websocketMs}ms`);
+  },
+};
+
+
+
+

--- a/bot/deploy-commands.js
+++ b/bot/deploy-commands.js
@@ -1,26 +1,52 @@
 require('dotenv').config();
+const fs = require('node:fs');
+const path = require('node:path');
 const { REST, Routes } = require('discord.js');
 
-const commands = [
-  {
-    name: 'ping',
-    description: 'Replies with Pong!',
-  },
-];
+// Collect command JSON from files in bot/commands
+const commands = [];
+const commandsPath = path.join(__dirname, 'commands');
+if (fs.existsSync(commandsPath)) {
+  const commandFiles = fs
+    .readdirSync(commandsPath)
+    .filter(fileName => fileName.endsWith('.js'));
+
+  for (const fileName of commandFiles) {
+    const filePath = path.join(commandsPath, fileName);
+    const command = require(filePath);
+    if (command && command.data && typeof command.data.toJSON === 'function') {
+      commands.push(command.data.toJSON());
+    }
+  }
+}
 
 const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);
 
 (async () => {
   try {
+    const clientId = process.env.CLIENT_ID;
+    const guildId = process.env.GUILD_ID;
+    if (!clientId) {
+      throw new Error('CLIENT_ID is not set in environment');
+    }
+
     console.log('Started refreshing application (/) commands.');
 
-    await rest.put(
-      Routes.applicationGuildCommands(process.env.CLIENT_ID, process.env.GUILD_ID),
-      { body: commands },
-    );
-
-    console.log('Successfully reloaded application (/) commands.');
+    if (guildId) {
+      await rest.put(
+        Routes.applicationGuildCommands(clientId, guildId),
+        { body: commands },
+      );
+      console.log('Successfully reloaded GUILD application (/) commands.');
+    } else {
+      await rest.put(
+        Routes.applicationCommands(clientId),
+        { body: commands },
+      );
+      console.log('Successfully reloaded GLOBAL application (/) commands.');
+    }
   } catch (error) {
     console.error(error);
+    process.exitCode = 1;
   }
 })();

--- a/bot/events/interactionCreate.js
+++ b/bot/events/interactionCreate.js
@@ -1,0 +1,26 @@
+module.exports = {
+  name: 'interactionCreate',
+  async execute(interaction) {
+    if (!interaction.isChatInputCommand()) return;
+    const command = interaction.client.commands.get(interaction.commandName);
+    if (!command) {
+      await interaction.reply({ content: 'Unknown command.', ephemeral: true });
+      return;
+    }
+    try {
+      await command.execute(interaction);
+    } catch (error) {
+      console.error(error);
+      const errorMsg = { content: 'There was an error while executing this command!', ephemeral: true };
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp(errorMsg);
+      } else {
+        await interaction.reply(errorMsg);
+      }
+    }
+  },
+};
+
+
+
+

--- a/bot/events/ready.js
+++ b/bot/events/ready.js
@@ -1,0 +1,11 @@
+module.exports = {
+  name: 'ready',
+  once: true,
+  execute(client) {
+    console.log(`Ready! Logged in as ${client.user.tag}`);
+  },
+};
+
+
+
+

--- a/bot/package.json
+++ b/bot/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "deploy": "node deploy-commands.js"
+    "deploy": "node deploy-commands.js",
+    "deploy:commands": "node deploy-commands.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
# feat(bot): implement slash command architecture with auto-discovery; add /ping; deploy script and docs

## Summary
- **Auto-load commands** from `bot/commands`
- **Auto-load events** from `bot/events`
- **Adds `/ping`** as a working example
- **Adds deploy script** to register commands
- **Improves docs** and adds `.env.example`

## Changes
- `bot/index.js`: dynamic loaders for commands and events; client login
- `bot/deploy-commands.js`: registers commands (global or per-guild via `GUILD_ID`)
- `bot/commands/ping.js`: example slash command
- `bot/events/interactionCreate.js`, `bot/events/ready.js`: core handlers
- `bot/README.md`: Quick Start, scripts, and env guidance
- `bot/.env.example`: environment template

## How it works
- On startup, the bot reads each module in `bot/commands/*.js` and registers `{ data, execute }` to `client.commands`.
- `interactionCreate` routes slash command invocations to the matching `execute`.
- `deploy-commands.js` reads `bot/commands` and registers with Discord via REST (global or per-guild).
- 
Example: Closes #14 

> Setup details are in `bot/README.md`.