### PR TITLE
fix: normalize email case and whitespace in auth

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -13,7 +13,13 @@ const signToken = (id) => {
 
 export const register = async (req, res) => {
   try {
-    const { username, email, password } = req.body;
+    // Normalize inputs: trim username, lowercase and trim email
+    const rawUsername = req.body.username;
+    const rawEmail = req.body.email;
+    const password = req.body.password;
+
+    const username = rawUsername?.toString().trim();
+    const email = rawEmail?.toString().trim().toLowerCase();
 
     if (!username || !email || !password) {
       return res
@@ -52,7 +58,11 @@ export const register = async (req, res) => {
 
 export const login = async (req, res) => {
   try {
-    const { email, password } = req.body;
+    // Normalize incoming email
+    const rawEmail = req.body.email;
+    const password = req.body.password;
+
+    const email = rawEmail?.toString().trim().toLowerCase();
 
     if (!email || !password) {
       return res


### PR DESCRIPTION
# 🚀 Pull Request

## Description

Fixed email case sensitivity and whitespace handling in authentication endpoints. Users can now log in successfully regardless of email case (e.g., "Saina@Gmail.com" vs "saina@gmail.com") or leading/trailing whitespace, preventing login failures due to case mismatches.

## Related Issue

 Closes #37 

## Type of Change

- [✅ ] Bug fix 🐛
- [ ] New feature 🌟
- [ ] Enhancement ⚡
- [ ] Documentation update 📚
- [ ] Refactoring ♻️

## How Has This Been Tested?

- ✅ Syntax validation: `node --check controllers/authController.js` passes
- ✅ Server starts successfully with MongoDB connection
- ✅ Code review: Email normalisation logic correctly implemented in both register and login endpoints
- ✅ Logic verification: Emails are trimmed and lowercased before database operations


## Checklist

- [✅ ] I followed the [Contributing Guide](CONTRIBUTING.md)
- [✅ ] My code follows the project’s style guidelines
- [✅] I performed a self-review of my code
- [✅] I updated documentation where necessary
- [✅ ] My changes generate no new warnings
