### PR TITLE
Add per-route rate limiting for auth endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,28 @@ MONGO_URI=your_mongodb_uri
 JWT_SECRET=your_jwt_secret
 FRONTEND_URL=your_frontend_url
 EMAIL_USERNAME=your_email
-EMAIL_PASSWORD-your_password
+EMAIL_PASSWORD=your_password
+
+# Rate limiting for authentication endpoints
+AUTH_LOGIN_MAX=10
+AUTH_LOGIN_WINDOW_MS=900000
+AUTH_REGISTER_MAX=5
+AUTH_REGISTER_WINDOW_MS=3600000
+```
+
+#### Rate Limiting Configuration
+
+The server includes rate limiting for authentication endpoints to prevent abuse:
+
+- **Login Protection**: `AUTH_LOGIN_MAX` attempts per `AUTH_LOGIN_WINDOW_MS` milliseconds (default: 10 per 15 minutes)
+- **Registration Protection**: `AUTH_REGISTER_MAX` attempts per `AUTH_REGISTER_WINDOW_MS` milliseconds (default: 5 per hour)
+
+When limits are exceeded, endpoints return:
+```json
+{
+  "success": false,
+  "message": "Too many login attempts. Try again later."
+}
 ```
 
 #### Example: `bot/.env`

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,3 +4,9 @@ JWT_SECRET=your_jwt_secret
 FRONTEND_URL=your_frontend_url
 EMAIL_USERNAME=your_email
 EMAIL_PASSWORD=your_password
+
+# Rate limiting for authentication endpoints
+AUTH_LOGIN_MAX=10
+AUTH_LOGIN_WINDOW_MS=900000
+AUTH_REGISTER_MAX=5
+AUTH_REGISTER_WINDOW_MS=3600000

--- a/server/index.js
+++ b/server/index.js
@@ -12,10 +12,13 @@ import rateLimit from "express-rate-limit";
 import morgan from "morgan";
 import mongoose from "mongoose"; // For DB status in health check
 
-// ✅ Connect to DB
+// Connect to DB
 connectDB();
 
 const app = express();
+
+// Trust proxy for accurate IP detection behind load balancers
+app.set("trust proxy", 1);
 
 // Middlewares
 app.use(express.json());
@@ -31,15 +34,30 @@ app.use(
 app.use(morgan("dev"));
 
 // Configurable CORS
-const allowedOrigins = process.env.CORS_ORIGINS?.split(",") || ["http://localhost:5173"];
+const allowedOrigins = process.env.CORS_ORIGINS?.split(",") || ["http://localhost:5173", "http://localhost:5000", "http://localhost:5001"];
 app.use(
   cors({
-
+    origin: allowedOrigins,
     credentials: true,
   })
 );
 
 // Routes
+app.get("/", (req, res) => {
+  res.json({
+    message: "Gamify API Server",
+    version: "1.0.0",
+    status: "running",
+    endpoints: {
+      health: "/api/health",
+      auth: "/api/auth/*",
+      users: "/api/users/*",
+      points: "/api/points/*",
+      newsletter: "/api/newsletter/*"
+    }
+  });
+});
+
 app.get("/api/health", (req, res) => {
   res.json({
     ok: true,
@@ -73,6 +91,6 @@ const PORT = process.env.PORT || 5173;
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "1h";
 
 app.listen(PORT, () => {
-  console.log(`✅ Server running on http://localhost:${PORT}`);
+  console.log(`Server running on http://localhost:${PORT}`);
   console.log(`JWT expires in: ${JWT_EXPIRES_IN}`);
 });

--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -1,9 +1,35 @@
 import express from "express";
+import rateLimit from "express-rate-limit";
 import { register, login } from "../controllers/authController.js";
 
 const router = express.Router();
 
-router.post("/register", register);
-router.post("/login", login);
+// Login rate limiter - stricter limits for login attempts
+const loginLimiter = rateLimit({
+  windowMs: parseInt(process.env.AUTH_LOGIN_WINDOW_MS) || 15 * 60 * 1000, // 15 minutes default
+  max: parseInt(process.env.AUTH_LOGIN_MAX) || 10, // 10 attempts per window
+  message: {
+    success: false,
+    message: "Too many login attempts. Try again later."
+  },
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
+
+// Registration rate limiter - prevent account creation abuse
+const registerLimiter = rateLimit({
+  windowMs: parseInt(process.env.AUTH_REGISTER_WINDOW_MS) || 60 * 60 * 1000, // 1 hour default
+  max: parseInt(process.env.AUTH_REGISTER_MAX) || 5, // 5 registrations per hour
+  message: {
+    success: false,
+    message: "Too many registration attempts. Try again later."
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+// Apply rate limiters to specific routes
+router.post("/register", registerLimiter, register);
+router.post("/login", loginLimiter, login);
 
 export default router;


### PR DESCRIPTION
# 🚀 Pull Request

## Description

 Adds strict, per-route rate limiting to authentication endpoints to mitigate brute-force and signup abuse. Specifically:

POST /api/auth/login — default 10 requests per 15 minutes per IP (configurable via env)
POST /api/auth/register — default 5 requests per hour per IP (configurable via env)
Consistent 429 JSON response when limits are exceeded
Preserves existing global rate limiter as a safety net
Adds app.set("trust proxy", 1) and dev-friendly CORS entries
Documents new env vars in README and [.env.example]

## Related Issue

Example: Closes #65 

## Type of Change

- [ ] Bug fix 🐛
- [X] New feature 🌟
- [ ] Enhancement ⚡
- [ ] Documentation update 📚
- [ ] Refactoring ♻️

## How Has This Been Tested?

Started server locally on a dev port (5001) to avoid macOS service collision on 5000.
Manually exercised login endpoint with curl (12 attempts). Observed:
Attempts 1–10: 401 Unauthorized (invalid credentials)
Attempts 11–12: 429 Too Many Requests with body: {"success":false,"message":"Too many login attempts. Try again later."}
Verified health endpoint and root route return 200 JSON.
Verified CORS allows dev origins and trust-proxy is set.

## Checklist

- [X] I followed the [Contributing Guide](CONTRIBUTING.md)
- [X] My code follows the project’s style guidelines
- [X] I performed a self-review of my code
- [X] I updated documentation where necessary
- [X] My changes generate no new warnings

This will be an official contribution for OSCI'25