### PR TITLE
fix: text overflow in Featured Templates section

### DIFF
--- a/client/src/components/Home.jsx
+++ b/client/src/components/Home.jsx
@@ -597,7 +597,7 @@ export const Home = () => {
             </p>
           </motion.div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 gap-8">
             {featuredGames.map((game) => (
               <motion.div
                 key={game.id}
@@ -624,7 +624,7 @@ export const Home = () => {
                     </span>
                   ))}
                 </div>
-                <div className="flex items-center justify-between">
+                <div className="flex flex-wrap items-center justify-between gap-3">
                   <div className="flex items-center">
                     {[...Array(5)].map((_, i) => (
                       <FaStar


### PR DESCRIPTION
# 🚀 Pull Request

## Description

Fixed the text overflow issue in the Featured Templates cards.
(Only CSS changes are made)
Applied CSS/Tailwind adjustments so the text truncates properly without breaking the layout.

## Related Issue
Closes #79

## Type of Change

- [ x ] Bug fix 🐛
- [ ] New feature 🌟
- [ ] Enhancement ⚡
- [ ] Documentation update 📚
- [ ] Refactoring ♻️

## How Has This Been Tested?

Tested locally on the client:
Verified that text in Featured Templates cards no longer overflows.
Checked on multiple screen sizes to ensure responsiveness.

## Screenshots 

<img width="560" height="819" alt="Screenshot 2025-09-13 191809" src="https://github.com/user-attachments/assets/458c53c2-374b-4d6b-b32a-af280d0cf00d" />

<img width="1920" height="1080" alt="Screenshot (243)" src="https://github.com/user-attachments/assets/d4dd6b88-7959-40bf-918e-296a8cd5039a" />


## Checklist

- [ x ] I followed the [Contributing Guide](CONTRIBUTING.md)
- [ x ] My code follows the project’s style guidelines
- [ x ] I performed a self-review of my code
- [ ] I updated documentation where necessary
- [ x ] My changes generate no new warnings
