### PR TITLE
Remove duplicate manifest link from index.html

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -12,7 +12,6 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/icon/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/icon/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/icon/favicon/favicon-16x16.png">
-    <link rel="manifest" href="/manifest.json">
     <link rel="mask-icon" href="/icon/favicon/safari-pinned-tab.svg" color="#4CAF50">
     <link rel="shortcut icon" href="/icon/favicon/favicon.ico">
     <meta name="msapplication-TileColor" content="#4CAF50">


### PR DESCRIPTION
# 🚀 Pull Request

## Description

Removed the link to the manifest file from the HTML.

## Related Issue

Closes #86 

## Type of Change

- [ ] Bug fix 🐛
- [ ] New feature 🌟
- [ ] Enhancement ⚡
- [ ] Documentation update 📚
- [x] Refactoring ♻️

## Checklist

- [x] I followed the [Contributing Guide](CONTRIBUTING.md)
- [x] My code follows the project’s style guidelines
- [x] I performed a self-review of my code
- [x] I updated documentation where necessary
- [x] My changes generate no new warnings