### PR TITLE
Add example for client/.env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,12 @@ GUILD_ID=your_guild_id
 API_URL=http://localhost:5000
 ```
 
+#### Example: `client/.env`
+
+```env
+VITE_API_URL=http://localhost:5000
+```
+
 ### 4. Run the App
 
 #### In separate terminals:


### PR DESCRIPTION
Fixes #109

## Summary
Added missing client/.env example in README Setup Environment 
Variables section. The instructions mention creating .env files 
in all three directories but the client/ example was missing.

## Changes Made
- Added client/.env example block with VITE_API_URL variable
- Placed it alongside the existing server/.env and bot/.env examples

## Type of Change
- [x] Documentation fix