### PR TITLE
docs: link deployment guide files in README #111

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,19 @@ cd client && npm run dev
 cd bot && node index.js
 ```
 
+## 🚀 Deployment
+
+Ready to deploy Gamify? We have detailed deployment guides to help you:
+
+| Guide | Description |
+|-------|-------------|
+| [📖 General Deployment Guide](DEPLOYMENT_GUIDE.md) | Step-by-step instructions for deploying the full stack app |
+| [☁️ Cloudflare Deployment Guide](CLOUDFLARE_DEPLOYMENT_README.md) | Guide for deploying on Cloudflare Workers & Pages |
+
+> 💡 New to deployment? Start with the [General Deployment Guide](DEPLOYMENT_GUIDE.md).
+
+---
+
 ---
 
 ## 🤝 Contributing


### PR DESCRIPTION
Fixes #111

## Summary
Added a new Deployment section to README.md that links to both 
existing deployment guide files. Previously, these files existed 
in the repo but were completely undiscoverable from the README, 
leaving developers with no idea how to deploy the project.

## Changes Made
- Added `## 🚀 Deployment` section to README.md
- Added link to DEPLOYMENT_GUIDE.md
- Added link to CLOUDFLARE_DEPLOYMENT_README.md
- Added a table format for clean presentation

## Type of Change
- [x] Documentation fix