### PR TITLE
refactor: enforce strict JWT secret configuration validation

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -3,7 +3,10 @@ import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import { resolveOrganizationId } from "../services/organizationService.js";
 
-const JWT_SECRET = process.env.JWT_SECRET || "changeme-super-secret";
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+	throw new Error("FATAL: JWT_SECRET environment variable is not defined!");
+}
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "1h";
 const BOOTSTRAP_ADMIN_EMAILS = (process.env.BOOTSTRAP_ADMIN_EMAILS || "")
 	.split(",")

--- a/server/controllers/discordController.js
+++ b/server/controllers/discordController.js
@@ -4,7 +4,10 @@ import DiscordGuild from "../models/DiscordGuild.js";
 import DiscordUser from "../models/DiscordUser.js";
 import { resolveOrganizationId } from "../services/organizationService.js";
 
-const JWT_SECRET = process.env.JWT_SECRET || "changeme-super-secret";
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+	throw new Error("FATAL: JWT_SECRET environment variable is not defined!");
+}
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "1h";
 
 const signToken = (id) =>

--- a/server/middlewares/authMiddleware.js
+++ b/server/middlewares/authMiddleware.js
@@ -1,7 +1,10 @@
 import jwt from "jsonwebtoken";
 import User from "../models/User.js";
 
-const JWT_SECRET = process.env.JWT_SECRET || "changeme-super-secret";
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+	throw new Error("FATAL: JWT_SECRET environment variable is not defined!");
+}
 
 export const protect = async (req, res, next) => {
 	let token;


### PR DESCRIPTION
Closes #148 

# Summary
Enforces strict backend verification checks for token signature configurations by removing fallback defaults.

# Changes Made
- Removed default `"changeme-super-secret"` fallbacks from:
  - `server/controllers/authController.js`
  - `server/middlewares/authMiddleware.js`
  - `server/controllers/discordController.js`
- Added configuration assertion logic to exit or crash on missing secrets.

# Testing
- Validated server startup locally with and without `.env` values.
- Verified compilation and route handling success.

# Impact
Eliminates a critical security vulnerability and aligns the codebase with production-grade secure coding principles.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
